### PR TITLE
feat: Harden API validation and global exception handling

### DIFF
--- a/Backend/src/main/java/com/vvw/AniverseBackend/controller/PostController.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/controller/PostController.java
@@ -1,25 +1,22 @@
 package com.vvw.AniverseBackend.controller;
 
+
 import com.vvw.AniverseBackend.dto.CreatePostDto;
 import com.vvw.AniverseBackend.dto.PostResponseDto;
 import com.vvw.AniverseBackend.entity.User;
 import org.springframework.data.domain.Sort;
-import com.vvw.AniverseBackend.service.UserService;
 
 import jakarta.validation.Valid;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-// import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.RestController;
 import com.vvw.AniverseBackend.dto.UpdatePostDto;
 import com.vvw.AniverseBackend.service.PostService;
 import lombok.RequiredArgsConstructor;
-import java.util.Map;
 import java.util.Set;
 
 import org.springframework.http.HttpStatus;
@@ -32,6 +29,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+
 
 @RestController
 @RequiredArgsConstructor

--- a/Backend/src/main/java/com/vvw/AniverseBackend/dto/CommentResponseDto.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/dto/CommentResponseDto.java
@@ -15,5 +15,4 @@ public class CommentResponseDto {
     private Long id;
     private String content;
     private LocalDateTime createdAt;
-    private UserResponseDto author;
 }

--- a/Backend/src/main/java/com/vvw/AniverseBackend/dto/UpdatePostDto.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/dto/UpdatePostDto.java
@@ -10,8 +10,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UpdatePostDto {
+    
+    @NotBlank(message = "Title cannot be empty")
     @Size(min=5, max=25, message = "Title should be of lenght 5-25")
     private String title;
+
+    @NotBlank(message = "Content cannot be empty")
     @Size(min=10, message = "Post should be Greater than 10 characters")
     private String content;
 }

--- a/Backend/src/main/java/com/vvw/AniverseBackend/handler/GlobalExceptionHandler.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/handler/GlobalExceptionHandler.java
@@ -5,14 +5,24 @@ import com.vvw.AniverseBackend.dto.ApiValidationErrorDto;
 import com.vvw.AniverseBackend.exceptions.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.fasterxml.jackson.databind.JsonMappingException.Reference;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -60,6 +70,107 @@ public class GlobalExceptionHandler {
                                 request.getRequestURI());
 
                 return new ResponseEntity<>(apiErrorDto, HttpStatus.BAD_REQUEST);
+        }
+
+        @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+        public ResponseEntity<ApiErrorDto> handleMethodNotSupported(HttpRequestMethodNotSupportedException ex, HttpServletRequest request) {
+                log.warn("Method Not Supported: {} tried {}  | URL: {}", request.getRemoteAddr(), ex.getMethod(), request.getRequestURI());
+                
+                String supportedMethods = ex.getSupportedMethods() != null 
+                        ? String.join(", ", ex.getSupportedMethods()) 
+                        : "Unknown";
+                
+                ApiErrorDto apiErrorDto = new ApiErrorDto(
+                        HttpStatus.METHOD_NOT_ALLOWED.value(),
+                        "Method Not Allowed",
+                        String.format("The HTTP '%s' method is not supported at this URL. Supported Methods : %s", ex.getMethod(), supportedMethods),
+                        request.getRequestURI());
+                return ResponseEntity
+                        .status(HttpStatus.METHOD_NOT_ALLOWED)
+                        .header(HttpHeaders.ALLOW, supportedMethods)
+                        .body(apiErrorDto);
+        }
+
+        @ExceptionHandler(HttpMessageNotReadableException.class)
+        public ResponseEntity<ApiErrorDto> handleHttpMessageNotReadable(
+                HttpMessageNotReadableException ex, 
+                HttpServletRequest request){
+                
+                log.warn("Malformed JSON or Missing Body: {} | URL: {}", ex.getMessage(), request.getRequestURI());
+                String detailedMessage = "The request body is missing or the JSON is malformed.";
+                
+                // 1. Handle Unrecognized Fields
+                if (ex.getCause() instanceof UnrecognizedPropertyException unrecognizedException) {
+                        String rogueField = unrecognizedException.getPropertyName();
+                        String allowedFields = unrecognizedException.getKnownPropertyIds().toString();
+                        detailedMessage = String.format("Unrecognized field '%s'. This API is strict. Allowed fields are: %s", 
+                                rogueField, allowedFields);
+                }
+                // 2. Handle Data Type Mismatches (String instead of Integer)
+                else if(ex.getCause() instanceof InvalidFormatException invalidFormatException){
+                        String fieldPath = invalidFormatException.getPath().stream()
+                                .map(Reference::getFieldName)
+                                .reduce((first, second) -> first + "." + second)
+                                .orElse("unknown_field");
+                        
+                        detailedMessage = String.format("Invalid value provided for field '%s'. Expected type: %s", 
+                                        fieldPath, 
+                                        invalidFormatException.getTargetType().getSimpleName());
+                }
+                // 3. Handle Completely Empty Body
+                else if(ex.getMessage() != null && ex.getMessage().contains("Required request body is missing")){
+                        detailedMessage = "The request body is missing.";       
+                }
+                ApiErrorDto apiErrorDto = new ApiErrorDto(
+                        HttpStatus.BAD_REQUEST.value(),
+                        "Bad Request",
+                        detailedMessage,
+                        request.getRequestURI()
+                );
+
+                return new ResponseEntity<>(apiErrorDto, HttpStatus.BAD_REQUEST);
+        }
+
+        @ExceptionHandler(DataIntegrityViolationException.class)
+        public ResponseEntity<ApiErrorDto> handleDataIntegrityViolation(
+                DataIntegrityViolationException ex, 
+                HttpServletRequest request) {
+        
+                // 1. Get the actual database error message (e.g., from PostgreSQL/MySQL)
+                String rootMsg = ex.getMostSpecificCause().getMessage();
+                log.warn("Database Constraint Violation: {} | URL: {}", rootMsg, request.getRequestURI());
+
+                String detailedMessage = "A database conflict occurred.";
+                HttpStatus status = HttpStatus.CONFLICT;
+
+                // 2. Safely parse the message for specific database constraints
+                if (rootMsg != null) {
+                        String lowerCaseMsg = rootMsg.toLowerCase();
+                        
+                        // Handle Unique Constraint Violations (e.g., username/email already taken)
+                        if (lowerCaseMsg.contains("duplicate") || lowerCaseMsg.contains("unique constraint")) {
+                        detailedMessage = "A record with this exact information already exists. Please use a different value.";
+                        } 
+                        // Handle Foreign Key Violations (e.g., trying to comment on a deleted post)
+                        else if (lowerCaseMsg.contains("foreign key") || lowerCaseMsg.contains("violates foreign key constraint")) {
+                        detailedMessage = "You are trying to reference a resource that does not exist or was deleted.";
+                        status = HttpStatus.BAD_REQUEST; // 400 or 422 is usually better than 409 for missing parents
+                        }
+                        // Handle Not Null Violations
+                        else if (lowerCaseMsg.contains("not null") || lowerCaseMsg.contains("cannot be null")) {
+                        detailedMessage = "A required piece of data was missing from your request.";
+                        status = HttpStatus.BAD_REQUEST;
+                        }
+                }
+
+                ApiErrorDto apiErrorDto = new ApiErrorDto(
+                        status.value(),
+                        status.getReasonPhrase(),
+                        detailedMessage,
+                        request.getRequestURI()
+                );
+
+                return new ResponseEntity<>(apiErrorDto, status);
         }
 
         @ExceptionHandler(ResourceAccessDeniedException.class)

--- a/Backend/src/main/resources/application.yml
+++ b/Backend/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:dev}
   application:
     name: AniverseBackend
+  
+  jackson:
+    deserialization:
+      fail-on-unknown-properties: true
 
 # spring.sql.init.data-locations=classpath:data.sql
 server:


### PR DESCRIPTION
1. Added strict DTO validation using @NotBlank to stop invalid data before DB hit.
2. Added 405 Method Not Allowed handler with supported Allow headers.
3. Improved 400 Bad Request handling for malformed JSON, wrong data types, unknown fields, and empty requests.
4. Added DataIntegrityViolationException handling for DB constraint errors like unique, foreign key, and null violations with proper status codes.