### PR TITLE
Fix long search queries breaking UI

### DIFF
--- a/Frontend/src/api/postsApi.ts
+++ b/Frontend/src/api/postsApi.ts
@@ -18,6 +18,7 @@ export type PostsResponse = {
     content: Post[],
     number: number,
     totalPages: number,
+    totalElements?: number,
     last: boolean
 }
 

--- a/Frontend/src/api/postsApi.ts
+++ b/Frontend/src/api/postsApi.ts
@@ -18,7 +18,7 @@ export type PostsResponse = {
     content: Post[],
     number: number,
     totalPages: number,
-    totalElements?: number,
+    totalElements: number,
     last: boolean
 }
 

--- a/Frontend/src/components/feed/EditorialFeed.tsx
+++ b/Frontend/src/components/feed/EditorialFeed.tsx
@@ -95,11 +95,6 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
   const [searchParams] = useSearchParams()
   const searchQuery = searchParams.get('q')?.trim() ?? ''
 
-  // Truncate query safely to prevent UI breakage from excessively long strings
-  const displayQuery = searchQuery.length > 30 
-    ? `${searchQuery.slice(0, 30)}...` 
-    : searchQuery;
-
   const tabs = feedTabs[mode]
   const copy = feedCopy[mode]
   const [activeTab, setActiveTab] = useState(mode === 'home' ? 'hot' : 'latest')
@@ -229,7 +224,7 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
                     Showing results for:
                   </span>
                   <span className="inline-block rounded-control bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary truncate max-w-[120px] sm:max-w-[240px]">
-                    "{displayQuery}"
+                    "{searchQuery}"
                   </span>
                   <span className="text-xs text-on-surface-variant/80 shrink-0">
                     ({totalMatches} match{totalMatches === 1 ? '' : 'es'})
@@ -268,8 +263,8 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
                 <p className="text-[11px] font-black uppercase tracking-[0.32em] text-primary">
                   Search Miss
                 </p>
-                <h2 className="mt-4 text-3xl font-black text-on-surface">
-                  Nothing matched "{displayQuery}".
+                <h2 className="mt-4 text-3xl font-black text-on-surface break-words">
+                  Nothing matched <span className="inline-block max-w-full truncate align-bottom">"{searchQuery}"</span>.
                 </h2>
                 <p className="mt-4 max-w-2xl text-base leading-7 text-on-surface-variant">
                   Try a broader title, author handle, or franchise keyword. The current feed filter is

--- a/Frontend/src/components/feed/EditorialFeed.tsx
+++ b/Frontend/src/components/feed/EditorialFeed.tsx
@@ -94,6 +94,12 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
   const location = useLocation()
   const [searchParams] = useSearchParams()
   const searchQuery = searchParams.get('q')?.trim() ?? ''
+
+  // Truncate query safely to prevent UI breakage from excessively long strings
+  const displayQuery = searchQuery.length > 30 
+    ? `${searchQuery.slice(0, 30)}...` 
+    : searchQuery;
+
   const tabs = feedTabs[mode]
   const copy = feedCopy[mode]
   const [activeTab, setActiveTab] = useState(mode === 'home' ? 'hot' : 'latest')
@@ -101,6 +107,7 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
   const sortParam = activeTab === 'deep' ? 'wordCount,desc' : 'createdAt,desc';
 
   const isSearchActive = Boolean(searchQuery);
+  
 
   // 1. Reset page to 0 when search query changes
   React.useEffect(() => {
@@ -126,6 +133,7 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
   const posts = data?.content || [];
   const hasNextPage = Boolean(data && !data.last);
 
+  const totalMatches = data?.totalElements ?? posts.length;
 
 
   const visiblePosts = useMemo(() => {
@@ -191,9 +199,7 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
                 </div>
 
                 <p className="text-sm text-on-surface-variant/70">
-                  {searchQuery
-                    ? `Results for "${searchQuery}"`
-                    : `${posts.length} manuscript${posts.length === 1 ? '' : 's'} loaded`}
+                  {`${posts.length} manuscript${posts.length === 1 ? '' : 's'} loaded`}
                 </p>
               </div>
             </div>
@@ -215,6 +221,30 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
                 </button>
               ))}
             </div>
+
+                        {isSearchActive && (
+              <div className="mb-6 flex items-center justify-between gap-4 border border-outline-variant bg-surface-container-low p-4 rounded-card shadow-sm">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="text-sm font-bold text-on-surface shrink-0">
+                    Showing results for:
+                  </span>
+                  <span className="inline-block rounded-control bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary truncate max-w-[120px] sm:max-w-[240px]">
+                    "{displayQuery}"
+                  </span>
+                  <span className="text-xs text-on-surface-variant/80 shrink-0">
+                    ({totalMatches} match{totalMatches === 1 ? '' : 'es'})
+                  </span>
+                </div>
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="border-outline-variant text-on-surface hover:bg-surface-container-high text-xs shrink-0"
+                >
+                  <Link to={clearSearchHref}>Clear Search</Link>
+                </Button>
+              </div>
+            )}
 
             <div className="mb-6 xl:hidden">
               <TrendingManuscripts trendingPosts={trendingPosts} canInteract={canInteract} />
@@ -239,7 +269,7 @@ function EditorialFeed({ authStatus = true, mode = 'home' }) {
                   Search Miss
                 </p>
                 <h2 className="mt-4 text-3xl font-black text-on-surface">
-                  Nothing matched "{searchQuery}".
+                  Nothing matched "{displayQuery}".
                 </h2>
                 <p className="mt-4 max-w-2xl text-base leading-7 text-on-surface-variant">
                   Try a broader title, author handle, or franchise keyword. The current feed filter is


### PR DESCRIPTION
Truncated the Long search queries to display neatly and not break the UI. in both the status and result section


- Added DisplayQuery (truncated query) dedicated search status bar 
- Updated Search Status bar
- Fixed showing search query to use display query

to fix the long search query breaking the ui

Previously the search status and result were breaking the UI

Now it does not by truncating the query

---
<img width="1102" height="730" alt="image" src="https://github.com/user-attachments/assets/91117af6-b8e9-46c9-b972-53ac14eb5b06" />
