### PR TITLE
Solved issue #85: feat: Add password visibility toggle and eye icons for user experience

### DIFF
--- a/Frontend/src/components/auth/AuthScene.tsx
+++ b/Frontend/src/components/auth/AuthScene.tsx
@@ -177,7 +177,8 @@ const AuthField = React.forwardRef(function AuthField(
           {...props}
         />
 
-        { // Toggle password visibility button if the field is a password field 
+        { 
+        /* Toggle password visibility button if the field is a password field */
         isPasswordField && (
           <div className="flex items-center">    
             <PasswordVisibilityToggle

--- a/Frontend/src/components/auth/AuthScene.tsx
+++ b/Frontend/src/components/auth/AuthScene.tsx
@@ -150,11 +150,11 @@ const AuthField = React.forwardRef(function AuthField(
   const isPasswordField = type === 'password'
   const [isPasswordVisible, setIsPasswordVisible] = React.useState(false)
   const localRef = React.useRef<HTMLInputElement | null>(null)
-  const setRef = (el: HTMLInputElement | null) => {
+  const setRef = React.useCallback((el: HTMLInputElement | null) => {
     localRef.current = el
     if (typeof ref === 'function') ref(el)
     else if (ref) (ref as React.RefObject<HTMLInputElement | null>).current = el
-  }
+  }, [ref])
   const resolvedType = isPasswordField ? (isPasswordVisible ? 'text' : 'password') : type
 
   return (

--- a/Frontend/src/components/auth/AuthScene.tsx
+++ b/Frontend/src/components/auth/AuthScene.tsx
@@ -1,6 +1,7 @@
 import React, { useId } from 'react'
 import { Link } from 'react-router-dom'
 import { cn } from '@/lib/utils'
+import { PasswordVisibilityToggle } from './PasswordVisibilityToggle'
 
 type AuthSceneProps = {
   sectionLabel?: string
@@ -134,6 +135,7 @@ const AuthField = React.forwardRef(function AuthField(
     helperLabel,
     helperHref,
     className,
+    type,
     ...props
   }: React.InputHTMLAttributes<HTMLInputElement> & {
     label: string
@@ -145,6 +147,16 @@ const AuthField = React.forwardRef(function AuthField(
 ) {
   const id = useId()
 
+  const isPasswordField = type === 'password'
+  const [isPasswordVisible, setIsPasswordVisible] = React.useState(false)
+  const localRef = React.useRef<HTMLInputElement | null>(null)
+  const setRef = (el: HTMLInputElement | null) => {
+    localRef.current = el
+    if (typeof ref === 'function') ref(el)
+    else if (ref) (ref as React.RefObject<HTMLInputElement | null>).current = el
+  }
+  const resolvedType = isPasswordField ? (isPasswordVisible ? 'text' : 'password') : type
+
   return (
     <div className="space-y-1.5">
       <label
@@ -153,17 +165,31 @@ const AuthField = React.forwardRef(function AuthField(
       >
         {label}
       </label>
-
-      <div className="rounded-control bg-surface-container-low border border-outline-variant/60 px-control-x py-1 transition-colors hover:bg-surface-container focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/20">
+      <div className="flex items-center rounded-control bg-surface-container-low border border-outline-variant/60 px-control-x py-1 transition-colors hover:bg-surface-container focus-within:border-primary focus-within:ring-1 focus-within:ring-primary/20">
         <input
           id={id}
-          ref={ref}
+          ref={setRef}
+          type={resolvedType}
           className={cn(
-            'h-control-h w-full border-0 bg-transparent text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-variant/45',
+            'flex-1 h-control-h border-0 bg-transparent text-sm text-on-surface outline-none transition-colors placeholder:text-on-surface-variant/45',
             className
           )}
           {...props}
         />
+
+        { // Toggle password visibility button if the field is a password field 
+        isPasswordField && (
+          <div className="flex items-center">    
+            <PasswordVisibilityToggle
+              visible={isPasswordVisible}
+              onToggle={() => {
+                setIsPasswordVisible((value) => !value)
+                localRef.current?.focus()
+              }}
+            />
+          </div>
+        )}
+
       </div>
 
       {helperLabel && helperHref ? (

--- a/Frontend/src/components/auth/EyeIcon.tsx
+++ b/Frontend/src/components/auth/EyeIcon.tsx
@@ -1,0 +1,37 @@
+import { JSX } from 'react'
+
+
+export const OpenEyeIcon = (): JSX.Element => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="h-5 w-5 text-on-surface-variant transition hover:text-on-surface-variant/70"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.5 12s3.5-6.5 9.5-6.5S21.5 12 21.5 12s-3.5 6.5-9.5 6.5S2.5 12 2.5 12z"
+      />
+      <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.5" fill="none" />
+    </svg>
+)
+
+export const ClosedEyeIcon = (): JSX.Element => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      className="h-5 w-5 text-on-surface-variant transition hover:text-on-surface-variant/70"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+      />
+    </svg>
+)

--- a/Frontend/src/components/auth/PasswordVisibilityToggle.tsx
+++ b/Frontend/src/components/auth/PasswordVisibilityToggle.tsx
@@ -1,0 +1,27 @@
+import React, { JSX } from "react"
+import { OpenEyeIcon, ClosedEyeIcon } from "./EyeIcon"
+
+type PasswordVisibilityToggleProps = {
+  visible: boolean
+  onToggle: () => void
+}
+
+const PasswordVisibilityToggle = ({
+  visible,
+  onToggle,
+}: PasswordVisibilityToggleProps) => {
+  const openEye = OpenEyeIcon
+  const closedEye = ClosedEyeIcon
+
+  return (
+    <button
+      onClick={onToggle}
+      type="button"
+      aria-pressed={visible}
+      aria-label={visible ? "Hide password" : "Show password"}
+    >
+      {visible ? closedEye() : openEye()}
+    </button>
+  )
+}
+export { PasswordVisibilityToggle }

--- a/Frontend/src/components/auth/PasswordVisibilityToggle.tsx
+++ b/Frontend/src/components/auth/PasswordVisibilityToggle.tsx
@@ -10,8 +10,8 @@ const PasswordVisibilityToggle = ({
   visible,
   onToggle,
 }: PasswordVisibilityToggleProps) => {
-  const openEye = OpenEyeIcon
-  const closedEye = ClosedEyeIcon
+  const openEye = <OpenEyeIcon />
+  const closedEye = <ClosedEyeIcon />
 
   return (
     <button
@@ -20,7 +20,7 @@ const PasswordVisibilityToggle = ({
       aria-pressed={visible}
       aria-label={visible ? "Hide password" : "Show password"}
     >
-      {visible ? closedEye() : openEye()}
+      {visible ? closedEye : openEye}
     </button>
   )
 }


### PR DESCRIPTION
### Summary
This PR addresses the missing password visibility control on the authentication screens. Users can now toggle password fields between masked and visible states while preserving the entered value.

### Issue
Password inputs on the login and signup screens were always masked and did not provide a way for users to verify the text they had entered. This created a usability issue and increased the likelihood of input mistakes.

### Changes

- Added a show/hide password toggle to the shared authentication input component.
- Implemented eye icons to indicate the current visibility state.
- Ensured password fields remain masked by default.
- Preserved the existing password value when toggling visibility.
- Kept the behavior consistent across both login and signup forms.

### Implementation Notes
The visibility state is handled locally within the shared auth field component, allowing the input type to switch between password and text without clearing or altering the entered content.