### PR TITLE
feat: implement useClickOutside hook for improved click handling outs…

### DIFF
--- a/Frontend/src/components/Header/Header.tsx
+++ b/Frontend/src/components/Header/Header.tsx
@@ -10,6 +10,7 @@ import LogoutBtn from './LogoutBtn'
 import UserAvatar from '../User/UserAvatar'
 import { normalizeBrandHex, useTheme } from '../ThemeProvider'
 import { motion, useScroll, useMotionValueEvent } from 'framer-motion'
+import { useClickOutside } from '@/hooks/useClickOutside'
 
 const navItems = [
   { name: 'Home', slug: '/' },
@@ -35,6 +36,9 @@ function Header() {
   const [searchValue, setSearchValue] = useState('')
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const { ref: settingsPanelRef, ...clickOutsideHandlers } = useClickOutside<HTMLDivElement>(() => {
+    setIsSettingsOpen(false)
+  }, isSettingsOpen)
   const isAuthRoute = location.pathname === '/login' || location.pathname === '/signup'
   const navControlClass = 'h-control-h'
   const userRole = useAppSelector((state) => state.auth.userData?.role);
@@ -82,6 +86,14 @@ function Header() {
     setColorInput(brandColor);
     setColorError('');
   }, [brandColor]);
+
+  useEffect(() => {
+    if (!isSettingsOpen) return;
+
+    requestAnimationFrame(() => {
+      settingsPanelRef.current?.focus();
+    });
+  }, [isSettingsOpen, settingsPanelRef]);
 
   const navRoutes = navItems.filter((item) => {
     if (item.slug === "/admin") {
@@ -136,7 +148,19 @@ function Header() {
 
   // Common Settings Dropdown Panel
   const renderSettingsPanel = () => (
-    <div className="absolute right-0 top-12 z-50 w-[min(18rem,calc(100vw-2rem))] rounded-card border border-outline-variant bg-surface-container-highest p-card shadow-elevation-2 animate-in fade-in slide-in-from-top-2 duration-200">
+    <div
+      ref={settingsPanelRef}
+      tabIndex={0}
+      role="dialog"
+      aria-label="Settings"
+      onClick={(event) => event.stopPropagation()}
+      {...clickOutsideHandlers}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          setIsSettingsOpen(false);
+        }
+      }}
+      className="absolute right-0 top-12 z-50 w-[min(18rem,calc(100vw-2rem))] rounded-card border border-outline-variant bg-surface-container-highest p-card shadow-elevation-2 animate-in fade-in slide-in-from-top-2 duration-200 ">
       <h3 className="text-xs font-black uppercase tracking-[0.16em] text-on-surface mb-3">Settings</h3>
       
       {/* Mode Selector */}
@@ -251,7 +275,12 @@ function Header() {
               <div className="relative shrink-0">
                 <button
                   type="button"
-                  onClick={() => setIsSettingsOpen((open) => !open)}
+                  data-settings-trigger="true"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setIsSettingsOpen((open) => !open);
+                  }}
+                  {...clickOutsideHandlers}
                   className="inline-flex size-9 sm:size-10 items-center justify-center border border-outline-variant text-on-surface hover:bg-surface-container transition-colors rounded-control cursor-pointer"
                   aria-label="Theme settings"
                   aria-expanded={isSettingsOpen}
@@ -292,7 +321,12 @@ function Header() {
               <div className="relative shrink-0">
                 <button
                   type="button"
-                  onClick={() => setIsSettingsOpen((open) => !open)}
+                  data-settings-trigger="true"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setIsSettingsOpen((open) => !open);
+                  }}
+                  {...clickOutsideHandlers}
                   className="inline-flex size-10 items-center justify-center border border-outline-variant text-on-surface hover:bg-surface-container transition-colors rounded-control cursor-pointer"
                   aria-label="Theme settings"
                   aria-expanded={isSettingsOpen}
@@ -398,7 +432,12 @@ function Header() {
                 <div className="relative shrink-0 hidden lg:inline-block">
                   <button
                     type="button"
-                    onClick={() => setIsSettingsOpen((open) => !open)}
+                    data-settings-trigger="true"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setIsSettingsOpen((open) => !open);
+                    }}
+                    {...clickOutsideHandlers}
                     className="inline-flex size-10 items-center justify-center border border-outline-variant text-on-surface hover:bg-surface-container transition-colors rounded-control cursor-pointer"
                     aria-label="Theme settings"
                     aria-expanded={isSettingsOpen}

--- a/Frontend/src/components/Header/Header.tsx
+++ b/Frontend/src/components/Header/Header.tsx
@@ -36,7 +36,7 @@ function Header() {
   const [searchValue, setSearchValue] = useState('')
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
-  const { ref: settingsPanelRef, ...clickOutsideHandlers } = useClickOutside<HTMLDivElement>(() => {
+  const settingsPanelRef = useClickOutside<HTMLDivElement>(() => {
     setIsSettingsOpen(false)
   }, isSettingsOpen)
   const isAuthRoute = location.pathname === '/login' || location.pathname === '/signup'
@@ -153,8 +153,7 @@ function Header() {
       tabIndex={0}
       role="dialog"
       aria-label="Settings"
-      onClick={(event) => event.stopPropagation()}
-      {...clickOutsideHandlers}
+      onPointerDown={(event) => event.stopPropagation()}
       onKeyDown={(event) => {
         if (event.key === 'Escape') {
           setIsSettingsOpen(false);
@@ -276,11 +275,8 @@ function Header() {
                 <button
                   type="button"
                   data-settings-trigger="true"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    setIsSettingsOpen((open) => !open);
-                  }}
-                  {...clickOutsideHandlers}
+                  data-click-outside-ignore="true"
+                  onClick={() => setIsSettingsOpen((open) => !open)}
                   className="inline-flex size-9 sm:size-10 items-center justify-center border border-outline-variant text-on-surface hover:bg-surface-container transition-colors rounded-control cursor-pointer"
                   aria-label="Theme settings"
                   aria-expanded={isSettingsOpen}
@@ -322,11 +318,8 @@ function Header() {
                 <button
                   type="button"
                   data-settings-trigger="true"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    setIsSettingsOpen((open) => !open);
-                  }}
-                  {...clickOutsideHandlers}
+                  data-click-outside-ignore="true"
+                  onClick={() => setIsSettingsOpen((open) => !open)}
                   className="inline-flex size-10 items-center justify-center border border-outline-variant text-on-surface hover:bg-surface-container transition-colors rounded-control cursor-pointer"
                   aria-label="Theme settings"
                   aria-expanded={isSettingsOpen}
@@ -433,11 +426,8 @@ function Header() {
                   <button
                     type="button"
                     data-settings-trigger="true"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      setIsSettingsOpen((open) => !open);
-                    }}
-                    {...clickOutsideHandlers}
+                    data-click-outside-ignore="true"
+                    onClick={() => setIsSettingsOpen((open) => !open)}
                     className="inline-flex size-10 items-center justify-center border border-outline-variant text-on-surface hover:bg-surface-container transition-colors rounded-control cursor-pointer"
                     aria-label="Theme settings"
                     aria-expanded={isSettingsOpen}

--- a/Frontend/src/hooks/useClickOutside.ts
+++ b/Frontend/src/hooks/useClickOutside.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from 'react'
-import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent, TouchEvent as ReactTouchEvent } from 'react'
 
 export function useClickOutside<T extends HTMLElement>(
   handler: () => void,
@@ -11,14 +10,19 @@ export function useClickOutside<T extends HTMLElement>(
   useEffect(() => {
     if (!enabled) return
 
-    const handlePointerDown = (event: Event) => {
+    const handlePointerDown = (event: PointerEvent) => {
       const target = event.target
 
       if (!(target instanceof Node)) return
 
-      const clickedInside = ref.current?.contains(target)
-      const clickedOnIgnoredElement =
-        target instanceof Element && target.closest(ignoreSelector)
+      const eventPath = event.composedPath?.() ?? []
+      const clickedInside =
+        eventPath.includes(ref.current as EventTarget) || ref.current?.contains(target)
+      const clickedOnIgnoredElement = eventPath.some((node) => {
+        if (!(node instanceof Element)) return false
+
+        return node.matches(ignoreSelector) || node.closest(ignoreSelector) !== null
+      })
 
       if (clickedInside || clickedOnIgnoredElement) {
         return
@@ -27,27 +31,12 @@ export function useClickOutside<T extends HTMLElement>(
       handler()
     }
 
-    document.addEventListener('mousedown', handlePointerDown)
-    document.addEventListener('touchend', handlePointerDown)
     document.addEventListener('pointerdown', handlePointerDown)
 
     return () => {
-      document.removeEventListener('mousedown', handlePointerDown)
-      document.removeEventListener('touchend', handlePointerDown)
       document.removeEventListener('pointerdown', handlePointerDown)
     }
   }, [enabled, handler, ignoreSelector])
 
-  const stopPropagation = (event: { stopPropagation: () => void }) => event.stopPropagation()
-
-  return {
-    ref,
-    onMouseDown: stopPropagation as (event: ReactMouseEvent<HTMLElement>) => void,
-    onMouseUp: stopPropagation as (event: ReactMouseEvent<HTMLElement>) => void,
-    onTouchStart: stopPropagation as (event: ReactTouchEvent<HTMLElement>) => void,
-    onTouchEnd: stopPropagation as (event: ReactTouchEvent<HTMLElement>) => void,
-    onTouchCancel: stopPropagation as (event: ReactTouchEvent<HTMLElement>) => void,
-    onPointerDown: stopPropagation as (event: ReactPointerEvent<HTMLElement>) => void,
-    onPointerUp: stopPropagation as (event: ReactPointerEvent<HTMLElement>) => void,
-  }
+  return ref
 }

--- a/Frontend/src/hooks/useClickOutside.ts
+++ b/Frontend/src/hooks/useClickOutside.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react'
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent, TouchEvent as ReactTouchEvent } from 'react'
+
+export function useClickOutside<T extends HTMLElement>(
+  handler: () => void,
+  enabled = true,
+  ignoreSelector = '[data-click-outside-ignore="true"]',
+) {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const handlePointerDown = (event: Event) => {
+      const target = event.target
+
+      if (!(target instanceof Node)) return
+
+      const clickedInside = ref.current?.contains(target)
+      const clickedOnIgnoredElement =
+        target instanceof Element && target.closest(ignoreSelector)
+
+      if (clickedInside || clickedOnIgnoredElement) {
+        return
+      }
+
+      handler()
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('touchend', handlePointerDown)
+    document.addEventListener('pointerdown', handlePointerDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('touchend', handlePointerDown)
+      document.removeEventListener('pointerdown', handlePointerDown)
+    }
+  }, [enabled, handler, ignoreSelector])
+
+  const stopPropagation = (event: { stopPropagation: () => void }) => event.stopPropagation()
+
+  return {
+    ref,
+    onMouseDown: stopPropagation as (event: ReactMouseEvent<HTMLElement>) => void,
+    onMouseUp: stopPropagation as (event: ReactMouseEvent<HTMLElement>) => void,
+    onTouchStart: stopPropagation as (event: ReactTouchEvent<HTMLElement>) => void,
+    onTouchEnd: stopPropagation as (event: ReactTouchEvent<HTMLElement>) => void,
+    onTouchCancel: stopPropagation as (event: ReactTouchEvent<HTMLElement>) => void,
+    onPointerDown: stopPropagation as (event: ReactPointerEvent<HTMLElement>) => void,
+    onPointerUp: stopPropagation as (event: ReactPointerEvent<HTMLElement>) => void,
+  }
+}


### PR DESCRIPTION
### Summary
This PR fixes the Theme Settings dropdown behavior so it now closes when the user clicks outside of it, matching standard dropdown UX and improving overall usability.
Previously, the dropdown remained open after outside clicks, which made the interaction feel inconsistent and less intuitive. The fix introduces a reusable outside-click handling pattern so this behavior is easy to apply to other components in the future.

### Problem
The Theme Settings dropdown did not dismiss when the user clicked outside of it. This caused the panel to remain visible until the user closed it manually or refreshed the page.

### Expected behavior
When the Theme Settings dropdown is open:
- clicking outside the dropdown should close it
- clicking inside the dropdown should keep it open
- the interaction should work reliably on both desktop and mobile/touch devices

### What changed
- added a **reusable** outside-click hook for dismissing overlays and menus
- applied it to the Theme Settings dropdown in the header
- preserved interaction inside the dropdown by preventing internal clicks from being treated as outside clicks
- kept the dropdown accessible and usable on touch devices

### Implementation details
A reusable hook named [useClickOutside](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was created in [useClickOutside.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
It handles outside-click dismissal by listening for typical outside interaction events and closing the target UI when the interaction happens outside the relevant element. The hook is intentionally reusable so the same logic can be applied to future menus, popovers, cards, or dropdown components.
The header implementation in [Header.tsx](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now uses this hook for the Theme Settings panel so that:
- the dropdown closes on backdrop/outside click
- the trigger button still opens and toggles the panel correctly
- internal interactions remain intact
- Why this approach
- This solution is cleaner and more maintainable than handling outside-click logic inline in each component. By extracting the behavior into a hook, the implementation is:

   - **reusable**
   - easier to maintain
   - consistent across similar UI patterns
   - simpler to extend later if needed
   - Files changed [Header.tsx](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [useClickOutside.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

### Verification
I verified the frontend still builds successfully by running:

`npm run build`
Result:

> Vite production build completed successfully

### Notes
This change addresses the issue directly and also sets up a reusable pattern for future dropdown-style components that should close on outside interaction.