### PR TITLE
fix(auth): configure refresh token cookie for cross-site access

### DIFF
--- a/Backend/src/main/java/com/vvw/AniverseBackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/controller/AuthController.java
@@ -31,10 +31,10 @@ public class AuthController {
         loginResponsDto.setRefToken(null);
         ResponseCookie cookie = ResponseCookie.from("refresh_token",refToken)
                 .httpOnly(true)
-                .secure(false)  // TODO: MAKE IT TRUE IN PROD
+                .secure(true)  // TODO: MAKE IT TRUE IN PROD
                 .path(COOKIE_PATH)
                 .maxAge(maxAgeSeconds)
-                .sameSite("Strict")
+                .sameSite("none")
                 .build();
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginResponsDto);
     }
@@ -46,10 +46,10 @@ public class AuthController {
         response.setRefToken(null);
         ResponseCookie cookie = ResponseCookie.from("refresh_token", newToken)
                 .httpOnly(true)
-                .secure(false) // TODO: MAKE IT TRUE IN PROD
+                .secure(true) 
                 .path(COOKIE_PATH)
                 .maxAge(refreshTokenService.getRefreshTokenDurationSeconds())
-                .sameSite("Strict")
+                .sameSite("none")
                 .build();
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(response);
     }


### PR DESCRIPTION
### Description
This PR fixes User being logged out in production env after a hard reload of the app.

---

### Context (Why)
The refresh token cookie was set to `SameSite=Strict`, which caused the browser to block it when the GitHub Pages frontend tried to talk to the AWS backend.

---

### Changes (How)
- Updated `ResponseCookie` in `AuthController.java` to use `SameSite=None` and `Secure`.
- Added `allowCredentials(true)` to `AppConfig.java`.