### PR TITLE
fix:always show comment edit, delete button on mobile screens keeping…

### DIFF
--- a/Frontend/src/components/comments/CommentItem.tsx
+++ b/Frontend/src/components/comments/CommentItem.tsx
@@ -67,7 +67,7 @@ export const CommentItem = ({comment, postId} : commentItemProps) => {
                         </div>
                         {
                             isOwner && (
-                                <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                                <div className="flex gap-2 opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 transition-opacity">
                                     <Button
                                         variant="ghost"
                                         size="sm"


### PR DESCRIPTION
## Description

This PR fixes a critical accessibility and UI issue on mobile devices where the **Edit** and **Delete** buttons for comments were invisible but still clickable, causing accidental interactions.

The responsive Tailwind classes have been updated to ensure these action buttons are **always visible on touch devices (mobile screens)** while preserving the existing **hover-only visibility on desktop devices**.

---

## Changes Made

- Updated the action button wrapper in `CommentItem.tsx`.
- Replaced the existing Tailwind classes:

  ```tsx
  opacity-0 group-hover:opacity-100
  ```

  with:

  ```tsx
  opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100
  ```

---

## Behavior

| Device Type | Before | After |
|-------------|--------|-------|
| **Mobile (Touch Devices)** | Buttons were invisible but clickable | Buttons are always visible |
| **Desktop (Hover Devices)** | Buttons appeared on hover | No change — buttons still appear on hover |
