### PR TITLE
Dev

### DIFF
--- a/Backend/src/main/java/com/vvw/AniverseBackend/config/properties/CookieProperties.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/config/properties/CookieProperties.java
@@ -1,0 +1,9 @@
+package com.vvw.AniverseBackend.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.cookie")
+public record CookieProperties(
+        boolean secure,
+        String sameSite
+) {}

--- a/Backend/src/main/java/com/vvw/AniverseBackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.vvw.AniverseBackend.controller;
 
 import com.vvw.AniverseBackend.dto.CreateUserDto;
 import com.vvw.AniverseBackend.dto.LoginRequestDto;
+import com.vvw.AniverseBackend.config.properties.CookieProperties;
 import com.vvw.AniverseBackend.dto.AuthenticationResponseDto;
 import com.vvw.AniverseBackend.dto.UserResponseDto;
 import com.vvw.AniverseBackend.service.AuthService;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.beans.factory.annotation.Value;
 
 @RestController
 @RequestMapping("/auth")
@@ -18,6 +20,8 @@ public class AuthController {
     private static final String COOKIE_PATH = "/api/v1/auth";
     private final AuthService authService;
     private final RefreshTokenService refreshTokenService;
+    private final CookieProperties cookieProperties;
+
     @PostMapping("/signup")
     public ResponseEntity<UserResponseDto> signup(@Valid @RequestBody CreateUserDto createUserDto){
         return new ResponseEntity<>(authService.signup(createUserDto), HttpStatus.CREATED);
@@ -31,10 +35,10 @@ public class AuthController {
         loginResponsDto.setRefToken(null);
         ResponseCookie cookie = ResponseCookie.from("refresh_token",refToken)
                 .httpOnly(true)
-                .secure(true)  // TODO: MAKE IT TRUE IN PROD
+                .secure(cookieProperties.secure())
                 .path(COOKIE_PATH)
                 .maxAge(maxAgeSeconds)
-                .sameSite("none")
+                .sameSite(cookieProperties.sameSite())
                 .build();
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginResponsDto);
     }
@@ -46,10 +50,10 @@ public class AuthController {
         response.setRefToken(null);
         ResponseCookie cookie = ResponseCookie.from("refresh_token", newToken)
                 .httpOnly(true)
-                .secure(true) 
+                .secure(cookieProperties.secure())
                 .path(COOKIE_PATH)
                 .maxAge(refreshTokenService.getRefreshTokenDurationSeconds())
-                .sameSite("none")
+                .sameSite(cookieProperties.sameSite())
                 .build();
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(response);
     }

--- a/Backend/src/main/java/com/vvw/AniverseBackend/controller/AuthController.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/controller/AuthController.java
@@ -31,10 +31,10 @@ public class AuthController {
         loginResponsDto.setRefToken(null);
         ResponseCookie cookie = ResponseCookie.from("refresh_token",refToken)
                 .httpOnly(true)
-                .secure(false)  // TODO: MAKE IT TRUE IN PROD
+                .secure(true)  // TODO: MAKE IT TRUE IN PROD
                 .path(COOKIE_PATH)
                 .maxAge(maxAgeSeconds)
-                .sameSite("Strict")
+                .sameSite("none")
                 .build();
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginResponsDto);
     }
@@ -46,10 +46,10 @@ public class AuthController {
         response.setRefToken(null);
         ResponseCookie cookie = ResponseCookie.from("refresh_token", newToken)
                 .httpOnly(true)
-                .secure(false) // TODO: MAKE IT TRUE IN PROD
+                .secure(true) 
                 .path(COOKIE_PATH)
                 .maxAge(refreshTokenService.getRefreshTokenDurationSeconds())
-                .sameSite("Strict")
+                .sameSite("none")
                 .build();
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(response);
     }

--- a/Backend/src/main/resources/application-dev.yml
+++ b/Backend/src/main/resources/application-dev.yml
@@ -15,5 +15,8 @@ spring:
     baseline-on-migrate: true # Safe fallback to baseline if database already has tables
 
 app:
+  cookie:
+    secure: false
+    same-site: "Lax"
   cors:
     allowed-origins: ${ALLOWED_ORIGINS}

--- a/Backend/src/main/resources/application-prod.yml
+++ b/Backend/src/main/resources/application-prod.yml
@@ -15,5 +15,8 @@ spring:
       mode: never # Never seed production with dev/test data
 
 app:
+  cookie:
+    secure: true
+    same-site: "None"
   cors:
     allowed-origins: ${ALLOWED_ORIGINS:https://aniverse.com}

--- a/Frontend/src/components/Header/Header.tsx
+++ b/Frontend/src/components/Header/Header.tsx
@@ -20,10 +20,13 @@ const navItems = [
 const headerVariants = {
   hidden: {
     y: "-100%",
-    opacity: 0
+    opacity: 0,
+    pointerEvents: "none",
   },
   visible: {
     y: 0,
+    opacity: 1, 
+    pointerEvents: "auto", 
   },
 };
 

--- a/Frontend/src/components/comments/CommentItem.tsx
+++ b/Frontend/src/components/comments/CommentItem.tsx
@@ -67,7 +67,7 @@ export const CommentItem = ({comment, postId} : commentItemProps) => {
                         </div>
                         {
                             isOwner && (
-                                <div className="flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                                <div className="flex gap-2 opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 transition-opacity">
                                     <Button
                                         variant="ghost"
                                         size="sm"


### PR DESCRIPTION
This PR fixes hard realod logging out users, Comment edit and delte buttons behaviour on mobile screen,  Hidden header  leaving ghost buttons.

### Changes:

The refresh token cookie was set to SameSite=Strict, which caused the browser to block it when the GitHub Pages frontend tried to talk to the AWS backend.
- Updated the action button wrapper in `CommentItem.tsx`.
- Replaced the existing Tailwind classes:

  ```tsx
  opacity-0 group-hover:opacity-100
  ```

  with:

  ```tsx
  opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100
  ```
- Added `pointerEvents: "none"` to the `hidden` Framer Motion variant.
- Added `pointerEvents: "auto"` (and explicitly restored `opacity: 1`) to the `visible` variant.