### PR TITLE
show correct post creation relative time

### DIFF
--- a/Frontend/src/components/PostCard.tsx
+++ b/Frontend/src/components/PostCard.tsx
@@ -10,7 +10,7 @@ import {
   getExcerpt,
   inferCategory,
 } from '@/lib/post-helpers'
-
+import { TimeAgo } from './ui/TimeAgo'
 function PostCard({
   id,
   title,
@@ -82,7 +82,9 @@ function PostCard({
           </span>
         )}
         <span className="shrink-0 text-on-surface-variant/40">/</span>
-        <span className="shrink-0">{formatRelativeTime(createdAt)}</span>
+        <TimeAgo 
+          timestamp={createdAt} 
+        />
       </div>
     </div>
   )

--- a/Frontend/src/components/ui/TimeAgo.tsx
+++ b/Frontend/src/components/ui/TimeAgo.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { formatRelativeTime } from '@/lib/post-helpers';
+
+interface TimeAgoProps {
+  timestamp: string | Date;
+  className?: string; // Allows you to pass Tailwind classes from PostCard
+}
+
+export function TimeAgo({ timestamp, className }: TimeAgoProps) {
+  // 1. Initialize with a deterministic state
+  const [mounted, setMounted] = useState(false);
+  const [timeString, setTimeString] = useState('');
+
+  // 2. Defer calculation to the client
+  useEffect(() => {
+    setMounted(true);
+    setTimeString(formatRelativeTime(timestamp));
+  }, [timestamp]);
+
+  // 3. Render identical fallback for Server and initial Client render
+  if (!mounted) {
+    // Renders an empty span with the exact same dimensions to prevent layout shift
+    return <span className={className}></span>; 
+  }
+
+  // 4. Render the client-calculated time
+  return <span className={className}>{timeString}</span>;
+}


### PR DESCRIPTION
- Added a reusable TimeAgo component to prevent React hydration mismatches by rendering relative timestamps only on the client.
- Updated PostCard to use <TimeAgo /> instead of directly calling formatRelativeTime(createdAt).
