### PR TITLE
feat(feedback): restrict feedback submission to authenticated regular…

### DIFF
--- a/Backend/src/main/java/com/vvw/AniverseBackend/controller/FeedbackController.java
+++ b/Backend/src/main/java/com/vvw/AniverseBackend/controller/FeedbackController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,6 +20,7 @@ public class FeedbackController {
     private final FeedbackService feedbackService;
 
     @PostMapping
+    @PreAuthorize("isAuthenticated() and !hasRole('ADMIN')")
     public ResponseEntity<FeedbackResponseDto> submitFeedback(@Valid @RequestBody FeedbackRequestDto requestDto) {
         FeedbackResponseDto response = feedbackService.createFeedback(requestDto);
         return new ResponseEntity<>(response, HttpStatus.CREATED);

--- a/Frontend/src/components/feedback/FeedbackModal.tsx
+++ b/Frontend/src/components/feedback/FeedbackModal.tsx
@@ -1,8 +1,15 @@
 import { Dialog, DialogContent, DialogTrigger, DialogTitle, DialogHeader, DialogClose } from "../ui/dialog";
 import { MessageSquarePlus, X } from "lucide-react";
 import FeedbackReport from "./FeedbackReport";
+import { usePermissions } from "@/hooks/usePermissions";
 
 export function FeedbackModal() {
+    const { canSubmitFeedback } = usePermissions();
+
+    if (!canSubmitFeedback) {
+        return null;
+    }
+
     return (
         <Dialog>
             <DialogTrigger asChild>
@@ -28,4 +35,4 @@ export function FeedbackModal() {
             </DialogContent>
         </Dialog>
     );
-}
+}

--- a/Frontend/src/hooks/usePermissions.ts
+++ b/Frontend/src/hooks/usePermissions.ts
@@ -1,0 +1,13 @@
+import { useAppSelector } from "@/store/hooks";
+
+export function usePermissions() {
+    const status = useAppSelector((state) => state.auth.status);
+    const role = useAppSelector((state) => state.auth.userData?.role);
+
+    return {
+        isGuest: !status,
+        isAdmin: role === "ADMIN",
+        isRegularUser: status && role !== "ADMIN",
+        canSubmitFeedback: status && role !== "ADMIN",
+    };
+}


### PR DESCRIPTION
## Summary
Hide add feedback functionality from admin and guest users by not showing feedback button.

## Problem
Since admin role is the one who will approve the feedbacks it does not feel right for admin to be able to submit feedbacks.
And since we want to show usernames of users who submit feedbacks on the github issue created from the feedback we need only the logged in users to be able to submit the feedbacks and also to prevent spam feedbacks.

## Changes
- Createad `usePermissions` hook to get  `canSubmitFeedback` which based on which we decide to show the feedback button or not.
- Added `@PreAuthorize("isAuthenticated() and !hasRole('ADMIN')")` to `submitFeedback` endpoint.

## Verfication
- Logged in as admin users and verified that feedback button is not shown
- Logged out and verified that feedback button is not shown