### PR TITLE
fix(deploy): add GitHub environment variables for webhook and API int…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,6 +153,9 @@ jobs:
             CLOUDINARY_KEY=${{ secrets.CLOUDINARY_KEY }}
             CLOUDINARY_SECRET=${{ secrets.CLOUDINARY_SECRET }}
             VITE_API_BASE_URL=https://${{ secrets.VPS_PUBLIC_DOMAIN }}/api/v1
+            GITHUB_REPO=VishalWadg/Aniverse
+            GITHUB_TOKEN=${{ secrets.GHCR_PAT }} 
+            GITHUB_WEBHOOK_SECRET=${{ secrets.GH_WEBHOOK_SECRET }}
             EOF
 
             cat <<'EOF' | sed 's/^[ \t]*//' > Caddyfile

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,6 +35,9 @@ services:
       CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME}
       CLOUDINARY_KEY: ${CLOUDINARY_KEY}
       CLOUDINARY_SECRET: ${CLOUDINARY_SECRET}
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
+      GITHUB_REPO: ${GITHUB_REPO}
+      GITHUB_WEBHOOK_SECRET: ${GITHUB_WEBHOOK_SECRET}
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/api/v1/actuator/health"]
       interval: 15s


### PR DESCRIPTION
## Summary

Added the required GitHub secrets needed for the webhook integration, including the GitHub token, repository, and webhook secret.

## Problem

Due to missing secrets:

- GitHub issue labels were not being seeded into the database, resulting in an empty array being returned by the suggest endpoint when users typed a feedback description.
- The feedback approval endpoint was not working and was returning the following error:

```json
{
  "status": 400,
  "error": "Bad Request",
  "message": "Not enough variable values available to expand 'GITHUB_REPO'"
}
```
## Changes
- Added the required secrets to the Compose file and deployment workflow.
- Added the required secrets to GitHub repository secrets.