### PR TITLE
fix: Remove trailing white space in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,7 +154,7 @@ jobs:
             CLOUDINARY_SECRET=${{ secrets.CLOUDINARY_SECRET }}
             VITE_API_BASE_URL=https://${{ secrets.VPS_PUBLIC_DOMAIN }}/api/v1
             GITHUB_REPO=VishalWadg/Aniverse
-            GITHUB_TOKEN=${{ secrets.GHCR_PAT }} 
+            GITHUB_TOKEN=${{ secrets.GHCR_PAT }}
             GITHUB_WEBHOOK_SECRET=${{ secrets.GH_WEBHOOK_SECRET }}
             EOF
 


### PR DESCRIPTION
## Summary
Find Fix the probable cause for ``` 500 Internal Server Error```

## Problem
Admin Feedback Approve endpoint is returning 

```
500 Internal Server Error
```
The probable cause is either Local .env used the developer PAT while production used container registry PAT (GHCR_PAT) or the trailing white space.

## Changes
Removed the trailing white space from the deploy.yml 