### PR TITLE
fix(deploy): use dedicated GitHub PAT for API integration in production environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,7 +154,7 @@ jobs:
             CLOUDINARY_SECRET=${{ secrets.CLOUDINARY_SECRET }}
             VITE_API_BASE_URL=https://${{ secrets.VPS_PUBLIC_DOMAIN }}/api/v1
             GITHUB_REPO=VishalWadg/Aniverse
-            GITHUB_TOKEN=${{ secrets.GHCR_PAT }}
+            GITHUB_TOKEN=${{ secrets.GH_BACKEND_PAT }}
             GITHUB_WEBHOOK_SECRET=${{ secrets.GH_WEBHOOK_SECRET }}
             EOF
 


### PR DESCRIPTION
## Summary
Fix 
```
500 ISE
```
Use correct `PAT` for **labels** and **issues** syncing and creations

## Problem
Admin feedback approve endpoint is returning 
```
500 Internal Server Error
```
when trying to approve user feedbacks 

## Changes 
**This fixes the probable cause for the issue**:
- Created `GH_BACKEND_PAT` with read write access to **issues** and **labels**
- Added `GH_BACKEND_PAT` to deploy in the env export to vps block as _GITHUB_TOKEN_ 